### PR TITLE
Prepare action for v0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Below are the arguments that can be provided to the Azure Container Apps Build a
 | `azureCredentials`        | No       | Azure credentials used by the `azure/login` action to authenticate Azure CLI requests if the user has not previously authenticated in the workflow calling this action. |
 | `imageToBuild`            | No       | The custom name of the image that is to be built, pushed to ACR and deployed to the Container App by this action. _Note_: this image name should include the ACR server; _e.g._, `<acr-name>.azurecr.io/<repo>:<tag>`. If this argument is not provided, a default image name will be constructed in the form `<acr-name>.azurecr.io/github-action/container-app:<github-run-id>.<github-run-attempt>` |
 | `imageToDeploy`           | No       | The custom name of the image that has already been pushed to ACR and will be deployed to the Container App by this action. _Note_: this image name should include the ACR server; _e.g._, `<acr-name>.azurecr.io/<repo>:<tag>`. If this argument is not provided, the value provided (or determined) for the `imageToBuild` argument will be used. |
-| `dockerfilePath`          | No       | Relative path to the Dockerfile in the provided application source that should be used to build the image that is then pushed to ACR and deployed to the Container App. If not provided, this action will check if there is a file named `Dockerfile` in the provided application source and use that to build the image. Otherwise, the Oryx++ Builder will be used to create the image. |
+| `dockerfilePath`          | No       | Relative path (_without file prefixes, see example below_) to the Dockerfile in the provided application source that should be used to build the image that is then pushed to ACR and deployed to the Container App. If not provided, this action will check if there is a file named `Dockerfile` in the provided application source and use that to build the image. Otherwise, the Oryx++ Builder will be used to create the image. |
 | `containerAppName`        | No       | The name of the Container App that will be created or updated. If not provided, this value will be `github-action-container-app-<github-run-id>-<github-run-attempt>`. |
 | `resourceGroup`           | No       | The resource group that the Container App will be created in, or currently exists in. If not provided, this value will be `<container-app-name>-rg`. |
 | `containerAppEnvironment` | No       | The name of the Container App environment to use with the application. If not provided, an existing environment in the resource group of the Container App will be used, otherwise, an environment will be created in the formation `<container-app-name>-env`. |
@@ -231,6 +231,34 @@ steps:
 
 This will create a new Container App named `github-action-container-app-<github-run-id>-<github-run-attempt>` in a new
 resource group named `<container-app-name>-rg` where the runnable application image is using the .NET 7 runtime stack.
+
+### Dockerfile provided
+
+```yml
+steps:
+
+  - name: Log in to Azure
+    uses: azure/login@v1
+    with:
+      creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+  - name: Build and deploy Container App
+    uses azure/container-app-deploy-action@v0
+    with:
+      appSourcePath: ${{ github.workspace }}
+      acrName: mytestacr
+      acrUsername: ${{ secrets.REGISTRY_USERNAME }}
+      acrPassword: ${{ secrets.REGISTRY_PASSWORD }}
+      dockerfilePath: test.Dockerfile
+```
+
+This will create a new Container App named `github-action-container-app-<github-run-id>-<github-run-attempt>` in a new
+resource group named `<container-app-name>-rg` where the runnable application image was created from the `test.Dockerfile`
+file found in the provided application source path directory.
+
+_Note_: for values provided to `dockerfilePath`, no file prefixes should be included (_e.g._, `./test.Dockerfile` should be
+passed as just `test.Dockerfile`). The provided `appSourcePath` and `dockerfilePath` arguments will be concatenated inside
+of the GitHub Action.
 
 ### Image to build provided
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -125,7 +125,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -148,7 +148,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -171,7 +171,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -197,7 +197,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -220,7 +220,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -243,7 +243,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -267,7 +267,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-app-deploy-action@main
+    uses azure/container-app-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
     - name: Export Dockerfile path to environment variable
       shell: bash
       run: |
-        CA_GH_ACTION_DOCKERFILE_PATH="${{ inputs.dockerfilePath }}"
+        CA_GH_ACTION_DOCKERFILE_PATH="${{ inputs.appSourcePath }}/${{ inputs.dockerfilePath }}"
         echo "CA_GH_ACTION_DOCKERFILE_PATH=${CA_GH_ACTION_DOCKERFILE_PATH}" >> $GITHUB_ENV
     
     - name: Check for existing Dockerfile in application source

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
       shell: bash
       run: |
         dockerfilePath=${{ inputs.appSourcePath }}/Dockerfile
-        if [ -f "$dockerfilePath" ]; then echo "CA_GH_ACTION_DOCKERFILE_PATH='Dockerfile'" >> $GITHUB_ENV; fi
+        if [ -f "$dockerfilePath" ]; then echo "CA_GH_ACTION_DOCKERFILE_PATH=${dockerfilePath}" >> $GITHUB_ENV; fi
 
     - name: Export name of image to build to environment variable
       shell: bash
@@ -172,7 +172,7 @@ runs:
       shell: bash
       run: |
         CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG="--environment ${{ inputs.containerAppEnvironment }}"
-        echo "CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG=${CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG}" >> $GITHUB_ENV        
+        echo "CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG=${CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG}" >> $GITHUB_ENV
     
     - name: Export runtime stack to environment variable
       shell: bash
@@ -195,12 +195,19 @@ runs:
         CA_GH_ACTION_TARGET_PORT="${{ inputs.targetPort }}"
         echo "CA_GH_ACTION_TARGET_PORT=${CA_GH_ACTION_TARGET_PORT}" >> $GITHUB_ENV
     
-    - name: Determine default target port if not provided
-      if: ${{ inputs.targetPort == '' }}
+    - name: Determine default target port if not provided and no Dockerfile provided/found
+      if: ${{ inputs.targetPort == '' && env.CA_GH_ACTION_DOCKERFILE_PATH == '' }}
       shell: bash
       run: |
         if [ ${{ env.CA_GH_ACTION_RUNTIME_STACK }} = python:* ]; then echo "CA_GH_ACTION_TARGET_PORT=80" >> $GITHUB_ENV; else echo "CA_GH_ACTION_TARGET_PORT=8080" >> $GITHUB_ENV; fi
     
+    - name: Export target port information to environment variable for Azure CLI command
+      if: ${{ inputs.targetPort == '' && env.CA_GH_ACTION_DOCKERFILE_PATH == '' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_TARGET_PORT_ARG="--target-port ${{ env.CA_GH_ACTION_TARGET_PORT }}"
+        echo "CA_GH_ACTION_TARGET_PORT_ARG=${CA_GH_ACTION_TARGET_PORT_ARG}" >> $GITHUB_ENV
+
     - name: Set Oryx++ Builder as default builder
       if: ${{ env.CA_GH_ACTION_DOCKERFILE_PATH == '' && inputs.imageToDeploy == '' }}
       shell: bash
@@ -224,4 +231,4 @@ runs:
     - name: Create or update Azure Container App
       shell: bash
       run: |
-        az containerapp up --name ${{ inputs.containerAppName }} --resource-group ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} --image ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} --target-port ${{ env.CA_GH_ACTION_TARGET_PORT }} ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG }} ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG }}
+        az containerapp up --name ${{ inputs.containerAppName }} --resource-group ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} --image ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} ${{ env.CA_GH_ACTION_TARGET_PORT_ARG }} ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG }} ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG }}


### PR DESCRIPTION
- Update `README.md` to reflect `v0` release
- Set `--target-port` argument in `az containerapp up` only if the default target port was determined and used
- Fix `docker build` issue where relative path for `Dockerfile` was used rather than absolute path
- Use absolute path when `dockerfilePath` argument is provided and used as a part of `docker build`