### PR TITLE
Add branding to action for release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,9 @@
 name: 'Oryx++ Builder GitHub Action'
 description: |
   'Uses the Oryx++ Builder to build a runnable image for an application and deploy it to an Azure Container App'
-
+branding:
+  icon: "login.svg"
+  color: "blue"
 inputs:
   appSourcePath:
     description: 'Absolute path on the GitHub runner of the source application code to be built.'


### PR DESCRIPTION
Add branding necessary for releasing this GitHub Action to the marketplace.

_Note_: the `login.svg` logo doesn't exist in the repository, but it's a pattern used by _most_ of the GitHub Actions released from the Azure organization -- I believe they will interject and set the logo to be the Azure icon when published.