### PR TITLE
Fix examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -125,7 +125,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -148,7 +148,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -171,7 +171,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -197,7 +197,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -220,7 +220,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -243,7 +243,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -271,7 +271,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr
@@ -295,7 +295,7 @@ steps:
       creds: ${{ secrets.AZURE_CREDENTIALS }}
 
   - name: Build and deploy Container App
-    uses azure/container-apps-deploy-action@v0
+    uses: azure/container-apps-deploy-action@v0
     with:
       appSourcePath: ${{ github.workspace }}
       acrName: mytestacr


### PR DESCRIPTION
Fix examples in `README.md` that were missing a colon when referencing the action via `uses`.