### PR TITLE
Update to argument validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,17 +91,17 @@ runs:
   using: "composite"
   steps:
     - name: Check for ACR name provided with application source path
-      if: ${{ inputs.appSourcePath != '' && inputs.acrName == '' }}
+      if: ${{ (inputs.appSourcePath != '' && inputs.acrName == '') || (inputs.appSourcePath == '' && inputs.acrName != '') }}
       shell: bash
       run: |
-        echo "The 'acrName' argument must be provided when providing the 'appSourcePath' argument."
+        echo "The 'appSourcePath' and 'acrName' arguments must either be provided together or not at all."
         exit 1
 
     - name: Check for application source path or previously built image when ACR name is provided
-      if: ${{ inputs.appSourcePath == '' && inputs.imageToDeploy == '' && inputs.acrName != '' }}
+      if: ${{ inputs.appSourcePath == '' && inputs.acrName == '' && inputs.imageToDeploy == '' }}
       shell: bash
       run: |
-        echo "Either the 'appSourcePath' or 'imageToDeploy' argument must be provided when providing the 'acrName' argument."
+        echo "The argument 'imageToDeploy' must be provided if neither 'appSourcePath' nor 'acrName' are provided."
         exit 1
 
     - name: Install pack CLI on non-Windows runner


### PR DESCRIPTION
- Ensure that `appSourcePath` and `acrName` are both provided and not provided at all
- Ensure that `imageToDeploy` is provided if `appSourcePath` and `acrName` are missing