### PR TITLE
Send telemetry with metadata about the action execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ with a call to `docker build` and the Container App will be created or updated b
 If a previously built image has already been pushed to the ACR instance and is provided to this action, no application
 source is required and the image will be used when creating or updating the Container App.
 
+## Data/Telemetry Collection Notice
+
+By default, this GitHub Action collects the following pieces of data for Microsoft:
+- The Container App build and deploy scenario targeted by the user
+  - _i.e._, used the Oryx++ Builder, used a provided/found Dockerfile, or provided a previously built image
+  - _Note_: the image name is _not_ collected
+- The processing time of the GitHub Action, in milliseconds
+- The result of the GitHub Action
+  - _i.e._, succeeded or failed
+- If the Oryx++ Builder is used, events and metrics relating to building the provided application using Oryx
+
+If you want to disable data collection, please set the `disableTelemetry` argument to `true`.
+
 ## Prerequisites
 
 Prior to running this action, a set of Azure resources and GitHub Actions are either required or optional depending on
@@ -123,6 +136,7 @@ need to be provided in order for this action to successfully run using one of th
 | `targetPort`              | No       | The target port that the Container App will listen on. If not provided, this value will be "80" for Python applications and "8080" for all other supported platforms. |
 | `location`                | No       | The location that the Container App (and other created resources) will be deployed to. To view locations suitable for creating the Container App in, please run the following: `az provider show -n Microsoft.App --query "resourceTypes[?resourceType=='containerApps'].locations"` |
 | `environmentVariables`    | No       | A list of environment variable(s) for the container. Space-separated values in 'key=value' format. Empty string to clear existing values. Prefix value with 'secretref:' to reference a secret. |
+| `disableTelemetry`        | No       | If set to `true`, no telemetry will be collected by this GitHub Action. If set to `false`, or if this argument is not provided, telemetry will be sent to Microsoft about the Container App build and deploy scenario targeted by this GitHub Action. |
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -86,10 +86,26 @@ inputs:
       'A list of environment variable(s) for the container. Space-separated values in 'key=value' format. Empty string
       to clear existing values. Prefix value with 'secretref:' to reference a secret.'
     required: false
+  disableTelemetry:
+    description: |
+      'If set to "true", no telemetry will be collected by this GitHub Action. If set to "false", or if this argument is
+      not provided, telemetry will be sent to Microsoft about the Container App build and deploy scenario targeted by
+      this GitHub Action.'
+    required: false
+    default: false
 
 runs:
   using: "composite"
   steps:
+    - name: Start timer to track action execution length, in milliseconds
+      if: ${{ always() && inputs.disableTelemetry == 'false' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_START_MILLISECONDS=$(date +%s%N | cut -b1-13)
+        echo "CA_GH_ACTION_START_MILLISECONDS=${CA_GH_ACTION_START_MILLISECONDS}" >> $GITHUB_ENV
+        CA_GH_ACTION_RESULT_ARG="--property 'result=failed'"
+        echo "CA_GH_ACTION_RESULT_ARG=${CA_GH_ACTION_RESULT_ARG}" >> $GITHUB_ENV
+
     - name: Check for ACR name provided with application source path
       if: ${{ inputs.appSourcePath != '' && inputs.acrName == '' }}
       shell: bash
@@ -269,10 +285,24 @@ runs:
       shell: bash
       run: pack config default-builder mcr.microsoft.com/oryx/builder:20230118.1
 
+    - name: Set telemetry for Oryx++ Builder
+      if: ${{ inputs.disableTelemetry == 'false' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG='--env "CALLER_ID=github-actions-v0"'
+        echo "CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG=${CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG}" >> $GITHUB_ENV
+
+    - name: Disable telemetry for Oryx++ Builder
+      if: ${{ inputs.disableTelemetry == 'true' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG='--env "ORYX_DISABLE_TELEMETRY=true"'
+        echo "CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG=${CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG}" >> $GITHUB_ENV
+
     - name: Create runnable application image using Oryx++ Builder
       if: ${{ inputs.appSourcePath != '' && env.CA_GH_ACTION_DOCKERFILE_PATH == '' }}
       shell: bash
-      run: pack build ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} --path ${{ inputs.appSourcePath }} --builder mcr.microsoft.com/oryx/builder:20230118.1 --run-image mcr.microsoft.com/oryx/${{ env.CA_GH_ACTION_RUNTIME_STACK }} --env "CALLER_ID=github-actions-v0"
+      run: pack build ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} --path ${{ inputs.appSourcePath }} --builder mcr.microsoft.com/oryx/builder:20230118.1 --run-image mcr.microsoft.com/oryx/${{ env.CA_GH_ACTION_RUNTIME_STACK }} ${{ env.CA_GH_ACTION_ORYX_BUILDER_TELEMETRY_ARG }}
 
     - name: Create runnable application image using provided Dockerfile
       if: ${{ inputs.appSourcePath != '' && env.CA_GH_ACTION_DOCKERFILE_PATH != '' }}
@@ -288,3 +318,46 @@ runs:
       shell: bash
       run: |
         az containerapp up --name ${{ inputs.containerAppName }} --resource-group ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} --image ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} ${{ env.CA_GH_ACTION_TARGET_PORT_ARG }} ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_ARG }} ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG }} ${{ env.CA_GH_ACTION_CONTAINER_APP_LOCATION_ARG }} ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG }}
+
+    - name: Mark action as 'succeeded' for telemetry
+      if: ${{ inputs.disableTelemetry == 'false' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_RESULT_ARG="--property 'result=succeeded'"
+        echo "CA_GH_ACTION_RESULT_ARG=${CA_GH_ACTION_RESULT_ARG}" >> $GITHUB_ENV
+
+    - name: End timer that's tracking action execution length, in milliseconds
+      if: ${{ always() && inputs.disableTelemetry == 'false' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_END_MILLISECONDS=$(date +%s%N | cut -b1-13)
+        CA_GH_ACTION_START_MILLISECONDS=${{ env.CA_GH_ACTION_START_MILLISECONDS }}
+        CA_GH_ACTION_LENGTH_MILLISECONDS_ARG="--processing-time '$((CA_GH_ACTION_END_MILLISECONDS-CA_GH_ACTION_START_MILLISECONDS))'"
+        echo "CA_GH_ACTION_LENGTH_MILLISECONDS_ARG=${CA_GH_ACTION_LENGTH_MILLISECONDS_ARG}" >> $GITHUB_ENV
+
+    - name: Set telemetry for previously built image scenario
+      if: ${{ inputs.disableTelemetry == 'false' && inputs.appSourcePath == '' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_SCENARIO_ARG="--property 'scenario=used-image'"
+        echo "CA_GH_ACTION_SCENARIO_ARG=${CA_GH_ACTION_SCENARIO_ARG}" >> $GITHUB_ENV
+
+    - name: Set telemetry for built Dockerfile scenario
+      if: ${{ inputs.disableTelemetry == 'false' && env.CA_GH_ACTION_DOCKERFILE_PATH != '' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_SCENARIO_ARG="--property 'scenario=used-dockerfile'"
+        echo "CA_GH_ACTION_SCENARIO_ARG=${CA_GH_ACTION_SCENARIO_ARG}" >> $GITHUB_ENV
+
+    - name: Set telemetry for no Dockerfile scenario
+      if: ${{ inputs.disableTelemetry == 'false' && inputs.appSourcePath != '' && env.CA_GH_ACTION_DOCKERFILE_PATH == '' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_SCENARIO_ARG="--property 'scenario=used-builder'"
+        echo "CA_GH_ACTION_SCENARIO_ARG=${CA_GH_ACTION_SCENARIO_ARG}" >> $GITHUB_ENV
+
+    - name: Log telemetry for action
+      if: ${{ always() && inputs.disableTelemetry == 'false' }}
+      shell: bash
+      run: |
+        docker run --rm mcr.microsoft.com/oryx/build:github-actions-debian-buster-20230206.2  /bin/bash -c "oryx telemetry --event-name 'ContainerAppsGitHubAction' ${{ env.CA_GH_ACTION_LENGTH_MILLISECONDS_ARG }} ${{ env.CA_GH_ACTION_SCENARIO_ARG }} ${{ env.CA_GH_ACTION_RESULT_ARG }}"


### PR DESCRIPTION
This PR introduces telemetry that tracks the following:
- The scenario targeted by the user
  - _i.e._, used builder, used Dockerfile, used image
- The time (in milliseconds) it took to execute the action
- The result of the action
  - _i.e._, succeeded or failed

This PR also introduces the `disableTelemetry` argument to allow users to opt out of Microsoft collecting data about their execution of the action.