### PR TITLE
fix: remove unexpected-symbol

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -272,7 +272,7 @@ runs:
       run: (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.27.0/pack-v0.27.0-${{ runner.os }}.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
 
     - name: Install pack CLI on Windows runner
-      if: ${{ runner.os == 'Windows' && inputs.appSourcePath != '' && && env.CA_GH_ACTION_DOCKERFILE_PATH == '' }}
+      if: ${{ runner.os == 'Windows' && inputs.appSourcePath != '' && env.CA_GH_ACTION_DOCKERFILE_PATH == '' }}
       shell: bash
       run: |
           mkdir -p $PWD/pack && cd $PWD/pack


### PR DESCRIPTION
Fixing the error: 
_Unexpected symbol: '&&'. Located at position 57 within expression: runner.os == 'Windows' && inputs.appSourcePath_