### PR TITLE
Add validation workflow to run after PR is merged to main

### DIFF
--- a/.github/workflows/run-validation-on-main.yml
+++ b/.github/workflows/run-validation-on-main.yml
@@ -1,0 +1,113 @@
+name: Run validation on main branch
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  TEST_FULL_ACR_NAME: ${{ vars.TEST_ACR_NAME }}.azurecr.io
+  TEST_IMAGE_REPOSITORY: github-actions/container-app
+
+jobs:
+  use-builder:
+    name: 'Validating builder scenario'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      TEST_IMAGE_TAG: 'bs-${{ github.run_id }}'
+      TEST_CONTAINER_APP_NAME: 'gh-ca-bs-${{ github.run_id }}'
+
+    steps:
+      - name: Clone Oryx repository
+        uses: actions/checkout@v3
+        with:
+          repository: microsoft/Oryx
+
+      - name: Log in to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Execute Azure Container Apps Build and Deploy Action
+        uses: Azure/container-apps-deploy-action@main
+        with:
+          appSourcePath: '${{ github.workspace }}/tests/SampleApps/DotNetCore/NetCore6PreviewWebApp'
+          acrName: ${{ vars.TEST_ACR_NAME }}
+          containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
+          resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
+          imageToBuild: ${{ env.TEST_FULL_ACR_NAME }}/${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }}
+          disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
+
+      - name: Delete created Azure Container App
+        shell: bash
+        run: az containerapp delete --name ${{ env.TEST_CONTAINER_APP_NAME }} --resource-group ${{ vars.TEST_RESOURCE_GROUP_NAME }} --yes
+
+      - name: Delete pushed image
+        shell: bash
+        run: az acr repository delete --name ${{ vars.TEST_ACR_NAME }} --image ${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }} --yes
+
+  use-dockerfile:
+    name: 'Validating Dockerfile scenario'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      TEST_IMAGE_TAG: 'ds-${{ github.run_id }}'
+      TEST_CONTAINER_APP_NAME: 'gh-ca-ds-${{ github.run_id }}'
+
+    steps:
+      - name: Clone Oryx repository
+        uses: actions/checkout@v3
+        with:
+          repository: microsoft/Oryx
+
+      - name: Log in to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Execute Azure Container Apps Build and Deploy Action
+        uses: Azure/container-apps-deploy-action@main
+        with:
+          appSourcePath: '${{ github.workspace }}/tests/SampleApps/DotNetCore/Blazor_Function_Sample/blazor-sample-app'
+          acrName: ${{ vars.TEST_ACR_NAME }}
+          containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
+          resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
+          imageToBuild: ${{ env.TEST_FULL_ACR_NAME }}/${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }}
+          disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
+
+      - name: Delete created Azure Container App
+        shell: bash
+        run: az containerapp delete --name ${{ env.TEST_CONTAINER_APP_NAME }} --resource-group ${{ vars.TEST_RESOURCE_GROUP_NAME }} --yes
+
+      - name: Delete pushed image
+        shell: bash
+        run: az acr repository delete --name ${{ vars.TEST_ACR_NAME }} --image ${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }} --yes
+
+  use-image:
+    name: 'Validating image scenario'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      TEST_CONTAINER_APP_NAME: 'gh-ca-ds-${{ github.run_id }}'
+
+    steps:
+      - name: Log in to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Execute Azure Container Apps Build and Deploy Action
+        uses: Azure/container-apps-deploy-action@main
+        with:
+          imageToDeploy: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+          containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
+          resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
+          disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
+
+      - name: Delete created Azure Container App
+        shell: bash
+        run: az containerapp delete --name ${{ env.TEST_CONTAINER_APP_NAME }} --resource-group ${{ vars.TEST_RESOURCE_GROUP_NAME }} --yes

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -1,9 +1,16 @@
-name: Run validation on main branch
+name: Run validation on action
 
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
 
 env:
   TEST_FULL_ACR_NAME: ${{ vars.TEST_ACR_NAME }}.azurecr.io
@@ -20,10 +27,14 @@ jobs:
       TEST_CONTAINER_APP_NAME: 'gh-ca-bs-${{ github.run_id }}'
 
     steps:
+      - name: Checkout action repository
+        uses: actions/checkout@v3
+
       - name: Clone Oryx repository
         uses: actions/checkout@v3
         with:
           repository: microsoft/Oryx
+          path: oryx
 
       - name: Log in to Azure
         uses: azure/login@v1
@@ -31,9 +42,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Execute Azure Container Apps Build and Deploy Action
-        uses: Azure/container-apps-deploy-action@main
+        uses: ./
         with:
-          appSourcePath: '${{ github.workspace }}/tests/SampleApps/DotNetCore/NetCore6PreviewWebApp'
+          appSourcePath: '${{ github.workspace }}/oryx/tests/SampleApps/DotNetCore/NetCore6PreviewWebApp'
           acrName: ${{ vars.TEST_ACR_NAME }}
           containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
           resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
@@ -41,10 +52,12 @@ jobs:
           disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
 
       - name: Delete created Azure Container App
+        if: ${{ always() }}
         shell: bash
         run: az containerapp delete --name ${{ env.TEST_CONTAINER_APP_NAME }} --resource-group ${{ vars.TEST_RESOURCE_GROUP_NAME }} --yes
 
       - name: Delete pushed image
+        if: ${{ always() }}
         shell: bash
         run: az acr repository delete --name ${{ vars.TEST_ACR_NAME }} --image ${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }} --yes
 
@@ -58,10 +71,14 @@ jobs:
       TEST_CONTAINER_APP_NAME: 'gh-ca-ds-${{ github.run_id }}'
 
     steps:
+      - name: Checkout action repository
+        uses: actions/checkout@v3
+
       - name: Clone Oryx repository
         uses: actions/checkout@v3
         with:
           repository: microsoft/Oryx
+          path: oryx
 
       - name: Log in to Azure
         uses: azure/login@v1
@@ -69,9 +86,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Execute Azure Container Apps Build and Deploy Action
-        uses: Azure/container-apps-deploy-action@main
+        uses: ./
         with:
-          appSourcePath: '${{ github.workspace }}/tests/SampleApps/DotNetCore/Blazor_Function_Sample/blazor-sample-app'
+          appSourcePath: '${{ github.workspace }}/oryx/tests/SampleApps/DotNetCore/Blazor_Function_Sample/blazor-sample-app'
           acrName: ${{ vars.TEST_ACR_NAME }}
           containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
           resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
@@ -79,10 +96,12 @@ jobs:
           disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
 
       - name: Delete created Azure Container App
+        if: ${{ always() }}
         shell: bash
         run: az containerapp delete --name ${{ env.TEST_CONTAINER_APP_NAME }} --resource-group ${{ vars.TEST_RESOURCE_GROUP_NAME }} --yes
 
       - name: Delete pushed image
+        if: ${{ always() }}
         shell: bash
         run: az acr repository delete --name ${{ vars.TEST_ACR_NAME }} --image ${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }} --yes
 
@@ -95,13 +114,16 @@ jobs:
       TEST_CONTAINER_APP_NAME: 'gh-ca-ds-${{ github.run_id }}'
 
     steps:
+      - name: Checkout action repository
+        uses: actions/checkout@v3
+
       - name: Log in to Azure
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Execute Azure Container Apps Build and Deploy Action
-        uses: Azure/container-apps-deploy-action@main
+        uses: ./
         with:
           imageToDeploy: 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
           containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
@@ -109,5 +131,6 @@ jobs:
           disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
 
       - name: Delete created Azure Container App
+        if: ${{ always() }}
         shell: bash
         run: az containerapp delete --name ${{ env.TEST_CONTAINER_APP_NAME }} --resource-group ${{ vars.TEST_RESOURCE_GROUP_NAME }} --yes

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           appSourcePath: '${{ github.workspace }}/oryx/tests/SampleApps/DotNetCore/NetCore6PreviewWebApp'
           acrName: ${{ vars.TEST_ACR_NAME }}
+          acrUsername: ${{ secrets.TEST_REGISTRY_USERNAME }}
+          acrPassword: ${{ secrets.TEST_REGISTRY_PASSWORD }}
           containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
           resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
           imageToBuild: ${{ env.TEST_FULL_ACR_NAME }}/${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }}
@@ -90,6 +92,8 @@ jobs:
         with:
           appSourcePath: '${{ github.workspace }}/oryx/tests/SampleApps/DotNetCore/Blazor_Function_Sample/blazor-sample-app'
           acrName: ${{ vars.TEST_ACR_NAME }}
+          acrUsername: ${{ secrets.TEST_REGISTRY_USERNAME }}
+          acrPassword: ${{ secrets.TEST_REGISTRY_PASSWORD }}
           containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
           resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NAME }}
           imageToBuild: ${{ env.TEST_FULL_ACR_NAME }}/${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }}

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -20,7 +20,7 @@ jobs:
   use-builder:
     name: 'Validating builder scenario'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     env:
       TEST_IMAGE_TAG: 'bs-${{ github.run_id }}'
@@ -64,7 +64,7 @@ jobs:
   use-dockerfile:
     name: 'Validating Dockerfile scenario'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     env:
       TEST_IMAGE_TAG: 'ds-${{ github.run_id }}'
@@ -108,7 +108,7 @@ jobs:
   use-image:
     name: 'Validating image scenario'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     env:
       TEST_CONTAINER_APP_NAME: 'gh-ca-ds-${{ github.run_id }}'

--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.TEST_AZURE_CREDENTIALS }}
 
       - name: Execute Azure Container Apps Build and Deploy Action
         uses: ./
@@ -83,7 +83,7 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.TEST_AZURE_CREDENTIALS }}
 
       - name: Execute Azure Container Apps Build and Deploy Action
         uses: ./
@@ -120,7 +120,7 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.TEST_AZURE_CREDENTIALS }}
 
       - name: Execute Azure Container Apps Build and Deploy Action
         uses: ./


### PR DESCRIPTION
This PR adds a GitHub Action workflow that will run when a PR is merged into `main` and does the following:

- Builds and deploys a Container App using the following three scenarios in parallel:
  - A previously built runnable application image is provided
  - A Dockerfile is provided/found in the application source
  - A runnable application image is built from the application source using the Oryx builder
- Deletes the Container App
- Deletes the image pushed to ACR (if any)

The service principal used to perform the CRUD operations will only have Contributor access over the test resource group that we'll be using (and the ACR resource inside of it).