### PR TITLE
Create resource group if it does not exist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -243,6 +243,42 @@ runs:
         CA_GH_ACTION_RESOURCE_GROUP="${{ inputs.containerAppName }}-rg"
         echo "CA_GH_ACTION_RESOURCE_GROUP=${CA_GH_ACTION_RESOURCE_GROUP}" >> $GITHUB_ENV
 
+    - name: Check if the resource group exists
+      shell: bash
+      run: |
+        az group show \
+          -n ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
+          -o none && CA_GH_ACTION_RG_EXISTS=true || CA_GH_ACTION_RG_EXISTS=false
+        echo "CA_GH_ACTION_RG_EXISTS=${CA_GH_ACTION_RG_EXISTS}" >> $GITHUB_ENV
+
+    - name: Get default location for Container Apps to use if resource group doesn't exist and location wasn't provided
+      if: ${{ env.CA_GH_ACTION_RG_EXISTS == 'false' && inputs.location == '' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_DEFAULT_LOCATION=$(az provider show -n Microsoft.App --query "resourceTypes[?resourceType=='containerApps'].locations[] | [0]")
+        if [[ $CA_GH_ACTION_DEFAULT_LOCATION == '' ]]; then
+          CA_GH_ACTION_DEFAULT_LOCATION="eastus2"
+        else
+          CA_GH_ACTION_DEFAULT_LOCATION=$(echo $CA_GH_ACTION_DEFAULT_LOCATION | sed 's/[ !()]//g')
+          CA_GH_ACTION_DEFAULT_LOCATION=${CA_GH_ACTION_DEFAULT_LOCATION,,}
+        fi
+        echo "CA_GH_ACTION_DEFAULT_LOCATION=${CA_GH_ACTION_DEFAULT_LOCATION}" >> $GITHUB_ENV
+
+    - name: Set default location for Container Apps if location was provided
+      if: ${{ env.CA_GH_ACTION_RG_EXISTS == 'false' && inputs.location != '' }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_DEFAULT_LOCATION="${{ inputs.location }}"
+        echo "CA_GH_ACTION_DEFAULT_LOCATION=${CA_GH_ACTION_DEFAULT_LOCATION}" >> $GITHUB_ENV
+
+    - name: Create resource group if it doesn't exist
+      if: ${{ env.CA_GH_ACTION_RG_EXISTS == 'false' }}
+      shell: bash
+      run: |
+        az group create \
+          -n ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
+          -l ${{ env.CA_GH_ACTION_DEFAULT_LOCATION }}
+
     - name: Export location argument to environment variable
       if: ${{ inputs.location != '' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
       shell: bash


### PR DESCRIPTION
Previously when we used the `az containerapp up` command to create a Container App, it would handle creating the resource group if it did not exist; however, when switching to the `az containerapp create` command, the expectation is that the resource group provided to the command exists, but we aren't currently handling the creation of the resource group that's provided or generated, which would cause the command to fail.