### PR TITLE
Update registry settings, if provided, for 'up' command call

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -470,6 +470,11 @@ jobs:
         shell: bash
         run: az acr repository delete -n ${{ vars.TEST_ACR_NAME }} -t ${{ env.TEST_IMAGE_REPOSITORY }}:${{ env.TEST_IMAGE_TAG }} -y
 
+      - name: Update Container App with existing image
+        if: ${{ always() }}
+        shell: bash
+        run: az containerapp update -n ${{ env.TEST_CONTAINER_APP_NAME }} -g ${{ vars.TEST_RESOURCE_GROUP_NAME }} -i mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
+
   update-using-image:
 
     name: 'Update app using image'

--- a/action.yml
+++ b/action.yml
@@ -521,6 +521,17 @@ runs:
         CA_GH_ACTION_USE_UP="true"
         echo "CA_GH_ACTION_USE_UP=${CA_GH_ACTION_USE_UP}" >> $GITHUB_ENV
 
+    - name: Update the Container Registry details on the existing Container App
+      if: ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG != '' && env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
+      shell: bash
+      run: |
+        az containerapp registry set \
+          -g ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
+          -n ${{ inputs.containerAppName }} \
+          --server ${{ inputs.acrName }}.azurecr.io \
+          --username ${{ inputs.acrUsername }} \
+          --password ${{ inputs.acrPassword }}
+
     - name: Update the existing Container App from provided arguments via 'update' (no ingress values provided)
       if: ${{ env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
       shell: bash
@@ -565,17 +576,6 @@ runs:
         az containerapp ingress disable \
           -g ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
           -n ${{ inputs.containerAppName }}
-
-    - name: Update the Container Registry details on the existing Container App
-      if: ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG != '' && env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
-      shell: bash
-      run: |
-        az containerapp registry set \
-          -g ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
-          -n ${{ inputs.containerAppName }} \
-          --server ${{ inputs.acrName }}.azurecr.io \
-          --username ${{ inputs.acrUsername }} \
-          --password ${{ inputs.acrPassword }}
 
     - name: Mark action as 'succeeded' for telemetry
       if: ${{ inputs.disableTelemetry == 'false' }}

--- a/action.yml
+++ b/action.yml
@@ -514,8 +514,15 @@ runs:
           -n ${{ inputs.containerAppName }} \
           --yaml ${{ inputs.yamlConfigPath }}
 
+    - name: Determine whether or not 'update' or 'up' should be used
+      if: ${{ env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && (inputs.targetPort != '' || inputs.ingress != '') }}
+      shell: bash
+      run: |
+        CA_GH_ACTION_USE_UP="true"
+        echo "CA_GH_ACTION_USE_UP=${CA_GH_ACTION_USE_UP}" >> $GITHUB_ENV
+
     - name: Update the existing Container App from provided arguments via 'update' (no ingress values provided)
-      if: ${{ env.CA_GH_ACTION_YAML_PROVIDED != 'true' && inputs.targetPort == '' && inputs.ingress == '' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
+      if: ${{ env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
       shell: bash
       run: |
         az containerapp update \
@@ -525,21 +532,21 @@ runs:
           ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG }}
 
     - name: Reset the ingress argument environment variable if it wasn't provided (use default ingress value)
-      if: ${{ env.CA_GH_ACTION_YAML_PROVIDED != 'true' && inputs.ingress == '' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
+      if: ${{ inputs.ingress == '' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
       shell: bash
       run: |
         CA_GH_ACTION_INGRESS_ARG=""
         echo "CA_GH_ACTION_INGRESS_ARG=${CA_GH_ACTION_INGRESS_ARG}" >> $GITHUB_ENV
 
     - name: Reset the environment variables argument environment variable for the 'up' command
-      if: ${{ env.CA_GH_ACTION_YAML_PROVIDED != 'true' && inputs.environmentVariables != '' }}
+      if: ${{ env.CA_GH_ACTION_USE_UP == 'true' && inputs.environmentVariables != '' }}
       shell: bash
       run: |
         CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG="--env-vars ${{ inputs.environmentVariables }}"
         echo "CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG=${CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG}" >> $GITHUB_ENV
 
     - name: Update the existing Container App from provided arguments via 'up' (ingress values provided)
-      if: ${{ env.CA_GH_ACTION_YAML_PROVIDED != 'true' && (inputs.targetPort != '' || inputs.ingress != '') && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
+      if: ${{ env.CA_GH_ACTION_USE_UP == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
       shell: bash
       run: |
         az containerapp up \
@@ -548,7 +555,8 @@ runs:
           -i ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} \
           ${{ env.CA_GH_ACTION_TARGET_PORT_ARG }} \
           ${{ env.CA_GH_ACTION_INGRESS_ARG }} \
-          ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG }}
+          ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG }} \
+          ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG }}
 
     - name: Disable ingress on the existing Container App
       if: ${{ env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && inputs.ingress == 'disabled' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
@@ -559,7 +567,7 @@ runs:
           -n ${{ inputs.containerAppName }}
 
     - name: Update the Container Registry details on the existing Container App
-      if: ${{ env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && env.CA_GH_ACTION_ACR_LOGIN_ARG != '' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
+      if: ${{ env.CA_GH_ACTION_ACR_LOGIN_ARG != '' && env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
       shell: bash
       run: |
         az containerapp registry set \

--- a/action.yml
+++ b/action.yml
@@ -546,7 +546,7 @@ runs:
         echo "CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG=${CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG}" >> $GITHUB_ENV
 
     - name: Update the existing Container App from provided arguments via 'up' (ingress values provided)
-      if: ${{ env.CA_GH_ACTION_USE_UP == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
+      if: ${{ env.CA_GH_ACTION_USE_UP == 'true' }}
       shell: bash
       run: |
         az containerapp up \


### PR DESCRIPTION
If the user provided the registry arguments (`acrName`, `acrUsername` and `acrPassword`) when deploying to an existing Container App, the corresponding `az containerapp up` command call does not include these registry values, deferring to an `az containerapp registry set` call _afterward_, which may result in the `up` command not correctly authorizing the Container App to pull the image from the registry.

This PR ensures that if these arguments were provided, they will be passed along with the `up` command call and the corresponding `registry set` call will be skipped. This does not affect the `update` command call flow where the `registry set` command call will be made afterwards.