### PR TITLE
Updated docker/login-action@v2.0.0 to v2.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
         creds: ${{ inputs.azureCredentials }}
 
     - name: Log in to Azure Container Registry
-      uses: docker/login-action@v2.0.0
+      uses: docker/login-action@v2.2.0
       if: ${{ inputs.acrName != '' && inputs.acrUsername != '' && inputs.acrPassword != '' }}
       with:
         registry: ${{ inputs.acrName }}.azurecr.io
@@ -191,7 +191,7 @@ runs:
         password: ${{ inputs.acrPassword }}
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v2.0.0
+      uses: docker/login-action@v2.2.0
       if: ${{ inputs.registryUrl != '' && inputs.registryUsername != '' && inputs.registryPassword != '' }}
       with:
         registry: ${{ inputs.registryUrl }}


### PR DESCRIPTION
Fixes following warning thrown when using this action:

```The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/Show more```