### PR TITLE
Remove env as a required arg

### DIFF
--- a/.github/workflows/run-validation.yml
+++ b/.github/workflows/run-validation.yml
@@ -89,7 +89,6 @@ jobs:
         with:
           appSourcePath: '${{ github.workspace }}/oryx/tests/SampleApps/DotNetCore/NetCore6PreviewWebApp'
           containerAppName: ${{ env.TEST_CONTAINER_APP_NAME }}
-          containerAppEnvironment: ${{ vars.TEST_EXISTING_CONTAINER_APP_ENV }}
           resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NO_ACR_NAME }}
           disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
 
@@ -464,7 +463,6 @@ jobs:
         with:
           appSourcePath: '${{ github.workspace }}/oryx/tests/SampleApps/DotNetCore/NetCore6PreviewWebApp'
           containerAppName: ${{ env.TEST_EXISTING_CONTAINER_APP }}
-          containerAppEnvironment: ${{ vars.TEST_EXISTING_CONTAINER_APP_ENV }}
           resourceGroup: ${{ vars.TEST_RESOURCE_GROUP_NO_ACR_NAME }}
           disableTelemetry: ${{ vars.TEST_DISABLE_TELEMETRY }}
 

--- a/azurecontainerapps.ts
+++ b/azurecontainerapps.ts
@@ -557,7 +557,7 @@ export class azurecontainerapps {
                 // Create the Container App from the YAML configuration file
                 await this.appHelper.createContainerAppFromYaml(this.containerAppName, this.resourceGroup, this.yamlConfigPath);
             } else if (createOrUpdateContainerAppWithUp) {
-                await this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.containerAppEnvironment, this.location, this.commandLineArgs);
+                await this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.commandLineArgs);
             } else {
                 // Create the Container App from command line arguments
                 await this.appHelper.createContainerApp(this.containerAppName, this.resourceGroup, this.containerAppEnvironment, this.commandLineArgs);
@@ -582,7 +582,7 @@ export class azurecontainerapps {
             // Update the Container App using the 'update' command
             await this.appHelper.updateContainerApp(this.containerAppName, this.resourceGroup, this.commandLineArgs);
         } else if (createOrUpdateContainerAppWithUp) {
-            await this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.containerAppEnvironment, this.location, this.commandLineArgs);
+            await this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.commandLineArgs);
         } else {
             // Update the Container App using the 'up' command
             await this.appHelper.updateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.commandLineArgs, this.ingress, this.targetPort);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4763,7 +4763,7 @@ var ContainerAppHelper = /** @class */ (function () {
     * @param optionalCmdArgs - a set of optional command line arguments
     * @param environment - the Container App Environment that will be associated with the Container App
     */
-    ContainerAppHelper.prototype.createOrUpdateContainerAppWithUp = function (containerAppName, resourceGroup, optionalCmdArgs, environment) {
+    ContainerAppHelper.prototype.createOrUpdateContainerAppWithUp = function (containerAppName, resourceGroup, optionalCmdArgs) {
         return __awaiter(this, void 0, void 0, function () {
             var command_2, err_2;
             return __generator(this, function (_a) {
@@ -4777,9 +4777,6 @@ var ContainerAppHelper = /** @class */ (function () {
                         optionalCmdArgs.forEach(function (val) {
                             command_2 += " ".concat(val);
                         });
-                        if (!util.isNullOrEmpty(environment)) {
-                            command_2 += " --environment ".concat(environment);
-                        }
                         return [4 /*yield*/, util.execute(command_2)];
                     case 2:
                         _a.sent();

--- a/dist/index.js
+++ b/dist/index.js
@@ -642,7 +642,7 @@ var azurecontainerapps = /** @class */ (function () {
                         return [3 /*break*/, 6];
                     case 2:
                         if (!createOrUpdateContainerAppWithUp) return [3 /*break*/, 4];
-                        return [4 /*yield*/, this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.containerAppEnvironment, this.location, this.commandLineArgs)];
+                        return [4 /*yield*/, this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.commandLineArgs)];
                     case 3:
                         _a.sent();
                         return [3 /*break*/, 6];
@@ -678,7 +678,7 @@ var azurecontainerapps = /** @class */ (function () {
                         return [3 /*break*/, 17];
                     case 13:
                         if (!createOrUpdateContainerAppWithUp) return [3 /*break*/, 15];
-                        return [4 /*yield*/, this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.containerAppEnvironment, this.location, this.commandLineArgs)];
+                        return [4 /*yield*/, this.appHelper.createOrUpdateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.commandLineArgs)];
                     case 14:
                         _a.sent();
                         return [3 /*break*/, 17];
@@ -4760,10 +4760,10 @@ var ContainerAppHelper = /** @class */ (function () {
     * Creates an Azure Container App.
     * @param containerAppName - the name of the Container App
     * @param resourceGroup - the resource group that the Container App is found in
-    * @param environment - the Container App Environment that will be associated with the Container App
     * @param optionalCmdArgs - a set of optional command line arguments
+    * @param environment - the Container App Environment that will be associated with the Container App
     */
-    ContainerAppHelper.prototype.createOrUpdateContainerAppWithUp = function (containerAppName, resourceGroup, environment, location, optionalCmdArgs) {
+    ContainerAppHelper.prototype.createOrUpdateContainerAppWithUp = function (containerAppName, resourceGroup, optionalCmdArgs, environment) {
         return __awaiter(this, void 0, void 0, function () {
             var command_2, err_2;
             return __generator(this, function (_a) {
@@ -4773,10 +4773,13 @@ var ContainerAppHelper = /** @class */ (function () {
                         _a.label = 1;
                     case 1:
                         _a.trys.push([1, 3, , 4]);
-                        command_2 = "az containerapp up -n ".concat(containerAppName, " -g ").concat(resourceGroup, " --environment ").concat(environment, " -l northcentralusstage");
+                        command_2 = "az containerapp up -n ".concat(containerAppName, " -g ").concat(resourceGroup, " -l northcentralusstage");
                         optionalCmdArgs.forEach(function (val) {
                             command_2 += " ".concat(val);
                         });
+                        if (!util.isNullOrEmpty(environment)) {
+                            command_2 += " --environment ".concat(environment);
+                        }
                         return [4 /*yield*/, util.execute(command_2)];
                     case 2:
                         _a.sent();

--- a/dist/index.js
+++ b/dist/index.js
@@ -4761,7 +4761,6 @@ var ContainerAppHelper = /** @class */ (function () {
     * @param containerAppName - the name of the Container App
     * @param resourceGroup - the resource group that the Container App is found in
     * @param optionalCmdArgs - a set of optional command line arguments
-    * @param environment - the Container App Environment that will be associated with the Container App
     */
     ContainerAppHelper.prototype.createOrUpdateContainerAppWithUp = function (containerAppName, resourceGroup, optionalCmdArgs) {
         return __awaiter(this, void 0, void 0, function () {

--- a/src/ContainerAppHelper.ts
+++ b/src/ContainerAppHelper.ts
@@ -55,19 +55,13 @@ export class ContainerAppHelper {
      public async createOrUpdateContainerAppWithUp(
         containerAppName: string,
         resourceGroup: string,
-        optionalCmdArgs: string[],
-        environment?: string) {
+        optionalCmdArgs: string[]) {
         toolHelper.writeDebug(`Attempting to create Container App with name "${containerAppName}" in resource group "${resourceGroup}"`);
         try {
             let command = `az containerapp up -n ${containerAppName} -g ${resourceGroup} -l northcentralusstage`;
             optionalCmdArgs.forEach(function (val: string) {
                 command += ` ${val}`;
             });
-
-            if (!util.isNullOrEmpty(environment)) {
-                command += ` --environment ${environment}`;
-            }
-
             await util.execute(command);
         } catch (err) {
             toolHelper.writeError(err.message);

--- a/src/ContainerAppHelper.ts
+++ b/src/ContainerAppHelper.ts
@@ -50,7 +50,6 @@ export class ContainerAppHelper {
      * @param containerAppName - the name of the Container App
      * @param resourceGroup - the resource group that the Container App is found in
      * @param optionalCmdArgs - a set of optional command line arguments
-     * @param environment - the Container App Environment that will be associated with the Container App
      */
      public async createOrUpdateContainerAppWithUp(
         containerAppName: string,

--- a/src/ContainerAppHelper.ts
+++ b/src/ContainerAppHelper.ts
@@ -49,21 +49,25 @@ export class ContainerAppHelper {
      * Creates an Azure Container App.
      * @param containerAppName - the name of the Container App
      * @param resourceGroup - the resource group that the Container App is found in
-     * @param environment - the Container App Environment that will be associated with the Container App
      * @param optionalCmdArgs - a set of optional command line arguments
+     * @param environment - the Container App Environment that will be associated with the Container App
      */
      public async createOrUpdateContainerAppWithUp(
         containerAppName: string,
         resourceGroup: string,
-        environment: string,
-        location: string,
-        optionalCmdArgs: string[]) {
+        optionalCmdArgs: string[],
+        environment?: string) {
         toolHelper.writeDebug(`Attempting to create Container App with name "${containerAppName}" in resource group "${resourceGroup}"`);
         try {
-            let command = `az containerapp up -n ${containerAppName} -g ${resourceGroup} --environment ${environment} -l northcentralusstage`;
+            let command = `az containerapp up -n ${containerAppName} -g ${resourceGroup} -l northcentralusstage`;
             optionalCmdArgs.forEach(function (val: string) {
                 command += ` ${val}`;
             });
+
+            if (!util.isNullOrEmpty(environment)) {
+                command += ` --environment ${environment}`;
+            }
+
             await util.execute(command);
         } catch (err) {
             toolHelper.writeError(err.message);


### PR DESCRIPTION
Remove `--environment` as a required argument for `up` because it is not set by the source control API template

Validation - https://github.com/Azure/container-apps-deploy-action/actions/runs/6789309970/job/18456202571