### PR TITLE
Swapping `up` command with `ingress update`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -616,15 +616,15 @@ runs:
           --yaml ${{ inputs.yamlConfigPath }} \
           --output none
 
-    - name: Determine whether or not 'update' or 'up' should be used
+    - name: Determine whether or not 'ingress update' should be used
       if: ${{ env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && (inputs.targetPort != '' || inputs.ingress != '') }}
       shell: bash
       run: |
-        CA_GH_ACTION_USE_UP="true"
-        echo "CA_GH_ACTION_USE_UP=${CA_GH_ACTION_USE_UP}" >> $GITHUB_ENV
+        CA_GH_ACTION_USE_INGRESS_UPDATE="true"
+        echo "CA_GH_ACTION_USE_INGRESS_UPDATE=${CA_GH_ACTION_USE_INGRESS_UPDATE}" >> $GITHUB_ENV
 
     - name: Update the Container Registry details on the existing Container App
-      if: ${{ env.CA_GH_ACTION_REGISTRY_LOGIN_ARG != '' && env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
+      if: ${{ env.CA_GH_ACTION_REGISTRY_LOGIN_ARG != '' && env.CA_GH_ACTION_USE_INGRESS_UPDATE != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}
       shell: bash
       run: |
         az containerapp registry set \
@@ -635,7 +635,7 @@ runs:
           --password ${{ env.CA_GH_ACTION_REGISTRY_PASSWORD }}
 
     - name: Update the existing Container App from provided arguments via 'update' (no ingress values provided)
-      if: ${{ env.CA_GH_ACTION_USE_UP != 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
+      if: ${{ env.CA_GH_ACTION_USE_INGRESS_UPDATE != 'true' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' && env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' }}
       shell: bash
       run: |
         az containerapp update \
@@ -653,24 +653,27 @@ runs:
         echo "CA_GH_ACTION_INGRESS_ARG=${CA_GH_ACTION_INGRESS_ARG}" >> $GITHUB_ENV
 
     - name: Reset the environment variables argument environment variable for the 'up' command
-      if: ${{ env.CA_GH_ACTION_USE_UP == 'true' && inputs.environmentVariables != '' }}
+      if: ${{ env.CA_GH_ACTION_USE_INGRESS_UPDATE == 'true' && inputs.environmentVariables != '' }}
       shell: bash
       run: |
         CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG="--env-vars ${{ inputs.environmentVariables }}"
         echo "CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG=${CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG}" >> $GITHUB_ENV
 
     - name: Update the existing Container App from provided arguments via 'up' (ingress values provided)
-      if: ${{ env.CA_GH_ACTION_USE_UP == 'true' }}
+      if: ${{ env.CA_GH_ACTION_USE_INGRESS_UPDATE == 'true' }}
       shell: bash
       run: |
-        az containerapp up \
+        az containerapp update \
           -g ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
           -n ${{ inputs.containerAppName }} \
           -i ${{ env.CA_GH_ACTION_IMAGE_TO_DEPLOY }} \
-          ${{ env.CA_GH_ACTION_TARGET_PORT_ARG }} \
-          ${{ env.CA_GH_ACTION_INGRESS_ARG }} \
           ${{ env.CA_GH_ACTION_CONTAINER_APP_ENVIRONMENT_VARIABLES_ARG }} \
-          ${{ env.CA_GH_ACTION_REGISTRY_LOGIN_ARG }}
+          --output none
+        az containerapp ingress update \
+          -n ${{ inputs.containerAppName }} \
+          -g ${{ env.CA_GH_ACTION_RESOURCE_GROUP }} \
+          ${{ env.CA_GH_ACTION_INGRESS_ARG/--ingress/--type}} \
+          ${{ env.CA_GH_ACTION_TARGET_PORT_ARG }}
 
     - name: Disable ingress on the existing Container App
       if: ${{ env.CA_GH_ACTION_RESOURCE_EXISTS == 'true' && inputs.ingress == 'disabled' && env.CA_GH_ACTION_YAML_PROVIDED != 'true' }}


### PR DESCRIPTION
Fixing the issue where up command fails to update a container app with a newer image version when ingress info is set. 